### PR TITLE
Remove external dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
   },
   "homepage": "https://github.com/FHIR/fhir.js",
   "dependencies": {
-    "@types/fhir": "0.0.30",
-    "merge": "^1.2.1"
+    "@types/fhir": "0.0.30"
   },
   "files": [
     "bin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fhir.js",
-  "version": "0.0.0",
+  "name": "lifen-fhir.js",
+  "version": "1.12.0",
   "devDependencies": {
     "babel-polyfill": "^6.7.4",
     "bower": "latest",
@@ -48,9 +48,7 @@
   "homepage": "https://github.com/FHIR/fhir.js",
   "dependencies": {
     "@types/fhir": "0.0.30",
-    "Base64": "~0.3.0",
-    "merge": "^1.2.1",
-    "q": "^1.4.1"
+    "merge": "^1.2.1"
   },
   "files": [
     "bin",

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -1,11 +1,10 @@
 (function() {
     var mw = require('./core');
 
-    var btoa = require('Base64').btoa;
-
     exports.$Basic = mw.$$Attr('headers.Authorization', function(args){
         if(args.auth && args.auth.user && args.auth.pass){
-            return "Basic " + btoa(args.auth.user + ":" + args.auth.pass);
+            var auth = Buffer.from(args.auth.user + ":" + args.auth.pass);
+            return "Basic " + auth.toString('base64');
         }
     });
 

--- a/src/middlewares/searchResultsAsGraph.js
+++ b/src/middlewares/searchResultsAsGraph.js
@@ -4,8 +4,6 @@
 
   var resolve = require('./references');
 
-  merge = require('merge');
-
   utils = require('../utils');
 
   ltype = utils.type;
@@ -27,7 +25,7 @@
         resolveRefs = function(value, context) {
           var mapto, ref;
           if (value.reference) {
-            mapto = resolve.sync(merge(true, params, {
+            mapto = resolve.sync(utils.merge(true, params, {
               reference: value,
               bundle: bundle,
               resource: resourceBoundary(context)
@@ -46,7 +44,7 @@
         });
         return success(graphify(bundle, entries));
       } : success;
-      return search(merge(true, params, {
+      return search(utils.merge(true, params, {
         success: graphCb
       }));
     };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,4 @@
 (function() {
-  var merge = require('merge');
-
   var RTRIM = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g;
 
   var trim = function(text) {
@@ -86,6 +84,13 @@
   };
 
   exports.argsArray = argsArray;
+  
+  var merge = function() {
+    const args = [{}].concat(Array.from(arguments));
+    return Object.assign.apply(null, args);
+  };
+  
+  exports.merge = merge;
 
   var mergeLists = function() {
     var reduce;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1720,11 +1720,6 @@ merge-descriptors@0.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-0.0.1.tgz#2ff0980c924cf81d0b5d1fb601177cb8bb56c0d0"
   integrity sha1-L/CYDJJM+B0LXR+2ARd8uLtWwNA=
 
-merge@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
-  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
-
 methods@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/methods/-/methods-0.1.0.tgz#335d429eefd21b7bacf2e9c922a8d2bd14a30e4f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,11 +7,6 @@
   resolved "https://registry.yarnpkg.com/@types/fhir/-/fhir-0.0.30.tgz#a0aec3b2d7dd2a7584474dac446ede5f9a4d7a13"
   integrity sha512-vDU62tUFeAYBVQThiWAfGd6D25TiLLDDS5pV19vim52FLpwWTBliLMvotbF4D/U+BmjxBKIuHGZgFnoh/HtV5g==
 
-Base64@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/Base64/-/Base64-0.3.0.tgz#6da261a4e80d4fa0f5c684254e5bccd16bbdce9f"
-  integrity sha1-baJhpOgNT6D1xoQlTlvM0Wu9zp8=
-
 accepts@~1.3.4:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -2164,11 +2159,6 @@ punycode@^1.2.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
-
-q@^1.4.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
-  integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
 qjobs@^1.1.4:
   version "1.2.0"


### PR DESCRIPTION
Remove all external dependencies.

- Q was not used.
- Base64 has been replaced by the using the stdlib Buffer.
- merge has been replaced by an implementation based on Object.assign.
 